### PR TITLE
Fix `rootFolder` option when zipping a folder

### DIFF
--- a/easy-zip.js
+++ b/easy-zip.js
@@ -89,6 +89,7 @@ EasyZip.prototype.zipFolder = function(folder, opts, callback) {
     var self = this;
     var hidden = false;
     var filter = null;
+    var rootFolder = path.basename(folder);
 
     function removeHidden(files) {
       return files.filter(function(file){
@@ -100,6 +101,7 @@ EasyZip.prototype.zipFolder = function(folder, opts, callback) {
     if (typeof opts === 'object') {
         hidden = (typeof opts.hidden !== 'undefined' ? opts.hidden : hidden);
         filter = (typeof opts.filter !== 'undefined' ? opts.filter : filter);
+        rootFolder = (typeof opts.rootFolder !== 'undefined' ? opts.rootFolder : rootFolder);
     }
     else if (typeof opts === 'function') {
         callback = opts;
@@ -114,8 +116,7 @@ EasyZip.prototype.zipFolder = function(folder, opts, callback) {
             if (!hidden) files = removeHidden(files);
             if (filter) files = files.filter(filter);
 
-            var rootFolder = path.basename(folder),
-                zips = [];
+            var zips = [];
 
             async.whilst(
                 function() { return files.length > 0 },

--- a/test.js
+++ b/test.js
@@ -48,10 +48,10 @@ zip5.zipFolder('../easy-zip2', function() {
 // zip a folder and change folder destination name
 console.log("zip a folder and change folder destination name");
 var zip6 = new EasyZip();
-zip6.zipFolder('../easy-zip2', function() {
-    zip6.writeToFile('folderall.zip');
-}, {
+zip6.zipFolder('../easy-zip2', {
     rootFolder: 'easy-zip6'
+}, function() {
+    zip6.writeToFile('folderall-changed-folder-name.zip');
 });
 
 // write data to http.Response


### PR DESCRIPTION
Looks like the `rootFolder` option when zipping a folder wasn’t being respected. Also the test case had the options argument in the wrong position.
