### PR TITLE
Fix an issue in zipFolder where callback was never called

### DIFF
--- a/easy-zip.js
+++ b/easy-zip.js
@@ -136,7 +136,7 @@ EasyZip.prototype.zipFolder = function(folder, opts, callback) {
             var zips = [];
 
             async.whilst(
-                function() { return files.length > 0 },
+                async function() { return files.length > 0 },
 
                 function(callback) {
                     var file = files.shift();


### PR DESCRIPTION
Fixed an issue with async.whilst usage in v3. 
For more details refer [this issue.](https://github.com/caolan/async/issues/1668).
Fixes #11 